### PR TITLE
Fix builder workflow to align architecture flags with CI matrix

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+        arch: ["aarch64", "amd64"]
 
     steps:
       - name: Check out repository

--- a/broadlink-ac-mqtt/config.yaml
+++ b/broadlink-ac-mqtt/config.yaml
@@ -6,9 +6,6 @@ url: "https://github.com/Arbuzov/hass-broadlink-ac-mqtt"
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
-  - i386
 init: false
 image: "ghcr.io/arbuzov/{arch}-addon-broadlink-ac-mqtt"
 options:


### PR DESCRIPTION
This pull request reduces the number of supported CPU architectures for the `broadlink-ac-mqtt` addon, both in its configuration and in the build workflow. Only `aarch64` and `amd64` architectures are now supported, which simplifies maintenance and potentially reduces build times.

**Architecture support reduction:**

* Updated the `arch` field in `broadlink-ac-mqtt/config.yaml` to only include `aarch64` and `amd64`, removing support for `armhf`, `armv7`, and `i386`.
* Modified the build matrix in `.github/workflows/builder.yaml` to only build for `aarch64` and `amd64`, matching the updated addon configuration.

## Summary by Sourcery

Align addon architecture support with the build workflow by limiting both to 64-bit platforms.

Enhancements:
- Limit the broadlink-ac-mqtt addon configuration to support only aarch64 and amd64 architectures, dropping armhf, armv7, and i386.

Build:
- Restrict the builder GitHub Actions workflow matrix to only build aarch64 and amd64 images.