### PR TITLE
Fix builder workflow to align architecture flags with CI matrix

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+        arch: ["aarch64", "amd64"]
 
     steps:
       - name: Check out repository

--- a/broadlink-ac-mqtt/config.yaml
+++ b/broadlink-ac-mqtt/config.yaml
@@ -6,9 +6,6 @@ url: "https://github.com/Arbuzov/hass-broadlink-ac-mqtt"
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
-  - i386
 init: false
 image: "ghcr.io/arbuzov/{arch}-addon-broadlink-ac-mqtt"
 options:


### PR DESCRIPTION
## Summary by Sourcery

Align addon build workflow and Broadlink AC MQTT addon metadata with supported architectures.

Enhancements:
- Restrict the builder GitHub Actions workflow architecture matrix to aarch64 and amd64.
- Update the Broadlink AC MQTT addon configuration to declare only aarch64 and amd64 architectures.