### PR TITLE
Skip unreachable AC devices on startup

### DIFF
--- a/broadlink-ac-mqtt/CHANGELOG.md
+++ b/broadlink-ac-mqtt/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.6.9
+
+- Patch upstream startup handling so an unreachable configured AC is retried five times, skipped, and does not prevent other configured ACs from starting
+- Avoid a tight daemon loop when no configured ACs are reachable after startup retries
+
 ## 0.6.8
 
 - Bump upstream to `Arbuzov/broadlink_ac_mqtt@1.2.3`, which restores the Linux config-path fallback that 1.2.2 had regressed (the broken Windows-style fallback caused `FileNotFoundError: '/usr/share/broadlink_ac_mqtt-1.2.2\\settings\\config.yml'` on add-on startup)

--- a/broadlink-ac-mqtt/Dockerfile
+++ b/broadlink-ac-mqtt/Dockerfile
@@ -3,11 +3,14 @@ FROM $BUILD_FROM
 
 COPY rootfs /
 
-RUN apk add --no-cache gcc g++ make libffi-dev openssl-dev \
+COPY patches /tmp/patches
+
+RUN apk add --no-cache gcc g++ make libffi-dev openssl-dev patch \
     && pip3 install --no-cache-dir -U \
     paho-mqtt \
     pyyaml \
     cryptography~=42.0 \
     && cd /usr/share \
     && wget -c https://github.com/Arbuzov/broadlink_ac_mqtt/archive/refs/tags/1.2.3.tar.gz -O - | tar -xz \
+    && patch -d /usr/share/broadlink_ac_mqtt-1.2.3 -p1 < /tmp/patches/skip-unreachable-devices.patch \
     && chmod a+x /etc/services.d/broadlink-ac-mqtt/*

--- a/broadlink-ac-mqtt/config.yaml
+++ b/broadlink-ac-mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: AC MQTT proxy for home assistant
-version: 0.6.8
+version: 0.6.9
 slug: broadlink-ac-mqtt
 description: Provides AC MQTT proxy for home assistant
 url: "https://github.com/Arbuzov/hass-broadlink-ac-mqtt"

--- a/broadlink-ac-mqtt/patches/skip-unreachable-devices.patch
+++ b/broadlink-ac-mqtt/patches/skip-unreachable-devices.patch
@@ -1,0 +1,26 @@
+diff --git a/broadlink_ac_mqtt/AcToMqtt.py b/broadlink_ac_mqtt/AcToMqtt.py
+index 183abec..37ad7e6 100644
+--- a/broadlink_ac_mqtt/AcToMqtt.py
++++ b/broadlink_ac_mqtt/AcToMqtt.py
+@@ -31,0 +32 @@ class AcToMqtt:
++	device_startup_attempts = 5
+@@ -76,2 +77,10 @@ class AcToMqtt:
+-		for device in device_list:			
+-			device_objects[device['mac']] = broadlink.gendevice(devtype=0x4E2a, host=(device['ip'],device['port']),mac = bytearray.fromhex(device['mac']), name=device['name'],update_interval = self.config['update_interval'])		
++		for device in device_list:
++			for attempt in range(1, self.device_startup_attempts + 1):
++				try:
++					device_objects[device['mac']] = broadlink.gendevice(devtype=0x4E2a, host=(device['ip'],device['port']),mac = bytearray.fromhex(device['mac']), name=device['name'],update_interval = self.config['update_interval'])
++					break
++				except (broadlink.ConnectError, OSError) as e:
++					logger.warning("Starting device %s at %s:%s failed on attempt %s/%s: %s" % (device['mac'], device['ip'], device['port'], attempt, self.device_startup_attempts, e))
++					logger.debug(traceback.format_exc())
++			else:
++				logger.error("Skipping device %s at %s:%s after %s failed startup attempts" % (device['mac'], device['ip'], device['port'], self.device_startup_attempts))
+@@ -94 +103 @@ class AcToMqtt:
+-		if 	devices == [] or devices == None:
++		if devices == [] or devices == None or devices == {}:
+@@ -97 +106,2 @@ class AcToMqtt:
+-			return
++			time.sleep(self.config["update_interval"])
++			return 0


### PR DESCRIPTION
## Summary
- Apply a small build-time patch to upstream `broadlink_ac_mqtt@1.2.3` so configured AC devices that are offline during startup are retried five times and then skipped.
- Keep reachable configured ACs running instead of aborting the whole add-on startup.
- Avoid a tight daemon loop when no configured ACs are reachable after startup retries.

## Root cause
Configured devices are constructed before the monitor loop starts, and that construction authenticates/polls the AC. If one configured IP is offline, `gendevice()` can raise `ConnectTimeout`; `monitor.py` catches it at the outer startup level, logs `Stopping`, and the Home Assistant service manager restarts the add-on.

## Validation
- `python -m unittest discover -s tests -v` against the patched upstream source: 2 tests passed.
- `git apply --check --unidiff-zero broadlink-ac-mqtt/patches/skip-unreachable-devices.patch` against a fresh `broadlink_ac_mqtt@1.2.3` checkout.
- `python -c "import yaml; yaml.safe_load(open('broadlink-ac-mqtt/config.yaml'))"`.
- `git diff --cached --check -- . ':!broadlink-ac-mqtt/patches/skip-unreachable-devices.patch'` before commit.

Docker image build was not run locally because the Docker Desktop Linux engine was unavailable in this environment.

Fixes #34

## Summary by Sourcery

Patch the upstream broadlink_ac_mqtt dependency so unreachable AC devices are retried on startup, then skipped without blocking other configured devices, and ensure the daemon does not spin when no devices are reachable.

Build:
- Add a build-time patching step and required tooling to apply skip-unreachable-devices.patch to the upstream broadlink_ac_mqtt source during image build.

Documentation:
- Update changelog to document version 0.6.9 with improved handling of unreachable AC devices on startup.

Chores:
- Bump add-on version from 0.6.8 to 0.6.9 in the add-on configuration.