### PR TITLE
fix: keep the MQTT thread alive when a command cannot be handled (0.6.10)

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -97,7 +97,9 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.06.0
+        # Pinned to the newest release that has a matching ghcr.io/home-assistant/{arch}-builder
+        # image. 2026.06.0 has no published image, so pulling it fails with "manifest unknown".
+        uses: home-assistant/builder@2026.03.2
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/broadlink-ac-mqtt/CHANGELOG.md
+++ b/broadlink-ac-mqtt/CHANGELOG.md
@@ -1,5 +1,12 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.6.10
+
+- Stop an MQTT command from killing the paho network thread: any exception raised while handling a message is now logged instead of escaping into the client loop (previously it silently ended all MQTT traffic until an add-on restart)
+- Fix `AttributeError: 'AcToMqtt' object has no attribute 'device_objects'` when a retained/queued command arrived between the MQTT connect and the first poll cycle
+- Ignore commands addressed to devices that were skipped as unreachable at startup, instead of raising `KeyError`
+- Match devices by MAC case-insensitively, so a MAC written in upper case in the add-on options no longer leaves that AC deaf to commands (state reporting always used the lower-case form the device reports)
+
 ## 0.6.9
 
 - Patch upstream startup handling so an unreachable configured AC is retried five times, skipped, and does not prevent other configured ACs from starting

--- a/broadlink-ac-mqtt/Dockerfile
+++ b/broadlink-ac-mqtt/Dockerfile
@@ -13,4 +13,5 @@ RUN apk add --no-cache gcc g++ make libffi-dev openssl-dev patch \
     && cd /usr/share \
     && wget -c https://github.com/Arbuzov/broadlink_ac_mqtt/archive/refs/tags/1.2.3.tar.gz -O - | tar -xz \
     && patch -d /usr/share/broadlink_ac_mqtt-1.2.3 -p1 < /tmp/patches/skip-unreachable-devices.patch \
+    && patch -d /usr/share/broadlink_ac_mqtt-1.2.3 -p1 < /tmp/patches/mqtt-callback-guard.patch \
     && chmod a+x /etc/services.d/broadlink-ac-mqtt/*

--- a/broadlink-ac-mqtt/config.yaml
+++ b/broadlink-ac-mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: AC MQTT proxy for home assistant
-version: 0.6.9
+version: 0.6.10
 slug: broadlink-ac-mqtt
 description: Provides AC MQTT proxy for home assistant
 url: "https://github.com/Arbuzov/hass-broadlink-ac-mqtt"

--- a/broadlink-ac-mqtt/patches/mqtt-callback-guard.patch
+++ b/broadlink-ac-mqtt/patches/mqtt-callback-guard.patch
@@ -1,0 +1,59 @@
+diff --git a/broadlink_ac_mqtt/AcToMqtt.py b/broadlink_ac_mqtt/AcToMqtt.py
+index 37ad7e6..f61c84c 100644
+--- a/broadlink_ac_mqtt/AcToMqtt.py
++++ b/broadlink_ac_mqtt/AcToMqtt.py
+@@ -30,6 +30,9 @@ class AcToMqtt:
+ 	previous_status = {}
+ 	last_update = {}
+ 	device_startup_attempts = 5
++	##connect_mqtt() starts the paho network thread before start() assigns the
++	##real device map, so callbacks must always find an attribute here.
++	device_objects = {}
+ 	
+ 	def __init__(self,config):
+ 		self.config = config
+@@ -77,7 +80,10 @@ class AcToMqtt:
+ 		for device in device_list:
+ 			for attempt in range(1, self.device_startup_attempts + 1):
+ 				try:
+-					device_objects[device['mac']] = broadlink.gendevice(devtype=0x4E2a, host=(device['ip'],device['port']),mac = bytearray.fromhex(device['mac']), name=device['name'],update_interval = self.config['update_interval'])
++					##Key on the lower-cased MAC: ac_db reports macaddress lower-cased,
++					##so that is what Home Assistant publishes commands to, whatever
++					##case the add-on config used.
++					device_objects[device['mac'].lower()] = broadlink.gendevice(devtype=0x4E2a, host=(device['ip'],device['port']),mac = bytearray.fromhex(device['mac']), name=device['name'],update_interval = self.config['update_interval'])
+ 					break
+ 				except (broadlink.ConnectError, OSError) as e:
+ 					logger.warning("Starting device %s at %s:%s failed on attempt %s/%s: %s" % (device['mac'], device['ip'], device['port'], attempt, self.device_startup_attempts, e))
+@@ -374,7 +380,17 @@ class AcToMqtt:
+ 	def _mqtt_on_subscribe(self,client, userdata, mid, granted_qos):
+ 		logger.debug("Mqtt Subscribed")
+ 		
+-	def _on_mqtt_message(self, client, userdata, msg):		
++	def _on_mqtt_message(self, client, userdata, msg):
++		##paho tears down its network thread when a callback raises, which kills
++		##every subscription and publish for the rest of the process life. Nothing
++		##may escape from here.
++		try:
++			self._handle_mqtt_message(client, userdata, msg)
++		except Exception as e:
++			logger.error("Error handling message on %s: %s" % (msg.topic, e))
++			logger.debug(traceback.format_exc())
++
++	def _handle_mqtt_message(self, client, userdata, msg):
+ 
+ 		try:
+ 			logger.debug('Mqtt Message Received! Userdata: %s, Message %s' % (userdata, msg.topic+" "+str(msg.payload)))
+@@ -392,6 +408,13 @@ class AcToMqtt:
+ 			return
+ 			
+ 		
++		##Devices that were skipped as unreachable, or commands arriving before
++		##start() published the device map, have no object to talk to.
++		address = address.lower()
++		if address not in self.device_objects:
++			logger.warning("Ignoring '%s' command for unknown device %s" % (function, address))
++			return
++
+ 		##Process received		##Probably need to exit here as well if command not send, but should exit on status update above .. grr, hate stupid python
+ 		if function ==  "temp":	
+ 			try:


### PR DESCRIPTION
## Problem

From a live add-on log:

```
Starting Monitor...
Exception in thread paho-mqtt-client-ac_to_mqtt:
  ...
  File "/usr/share/broadlink_ac_mqtt-1.2.3/broadlink_ac_mqtt/AcToMqtt.py", line 474, in _on_mqtt_message
    status = self.device_objects[address].set_homeassistant_mode(value)
AttributeError: 'AcToMqtt' object has no attribute 'device_objects'
(200, ('192.168.99.14', 80))
Stopping
```

`paho` tears down its network thread as soon as an `on_message` callback raises, and it never comes back — every subscription and publish stops for the rest of the process life, while the poll loop keeps running and the add-on looks healthy.

Three ways a command reached that state:

- `monitor.py` calls `connect_mqtt()` — which does `loop_start()` and subscribes to `<prefix>+/+/set` in `_on_mqtt_connect` — **before** `make_device_objects()`, but `self.device_objects` is only ever assigned inside `AcToMqtt.start()`. A retained/queued command landing in that window raised `AttributeError`.
- 0.6.9 skips ACs that are unreachable at startup, so a command for a skipped MAC raised `KeyError` in the branches that have no `try/except` (`power`, `mode`, `fanspeed`, `fanspeed_homeassistant`, `mode_homekit`, `mode_homeassistant`, `state`).
- `ac_db.send_packet` raises `ConnectTimeout` when an AC stops answering mid-command.

The `(200, ('192.168.99.14', 80))` / `Stopping` lines in the same log are a separate failure — an unreachable AC aborting startup — already fixed by 0.6.9.

## Fix

New `patches/mqtt-callback-guard.patch`, applied after `skip-unreachable-devices.patch`:

- `_on_mqtt_message` becomes a thin wrapper that logs anything escaping the dispatch, which moves to `_handle_mqtt_message`. A wrapper rather than a `try:` around the whole dispatch, to avoid re-indenting ~200 lines of upstream code.
- Class attribute `device_objects = {}` so callbacks always find a device map, even before `start()` runs.
- An unknown-device guard turns a command for a missing AC into a warning instead of an exception.
- Devices are keyed by the lower-cased MAC, and the decoded topic address is lower-cased: `ac_db` builds `status['macaddress']` with `format(x,'02x')` and the discovery command topics come from that, so a MAC written in upper case in the add-on options produced working state reporting and commands that never matched.

## Verification

- Both patches apply to a pristine 1.2.3 in Dockerfile order; `py_compile` passes.
- Applying `mqtt-callback-guard.patch` first fails hunk #1 with exit 1, so the `&&` chain aborts the build rather than producing a half-patched image.
- Four scenarios exercised against the patched source, none of which let an exception escape `_on_mqtt_message`: a command before `start()`, a command for a skipped device, a `ConnectTimeout` raised inside `set_homeassistant_mode`, and an upper-case MAC in the topic.

`config.yaml` is bumped to 0.6.10 — `MONITORED_FILES` in `builder.yaml` does not include `patches/`, so a patch-only change would not trigger a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Guard MQTT message handling callbacks so exceptions no longer terminate the paho network thread and update the add-on release to 0.6.10.

Bug Fixes:
- Prevent MQTT callback exceptions from killing the paho network thread, ensuring MQTT traffic continues after malformed or failing commands.
- Avoid AttributeError when retained or early MQTT commands arrive before device objects are initialized.
- Ignore MQTT commands targeting devices skipped as unreachable at startup instead of raising KeyError.
- Handle MAC address matching case-insensitively so devices configured with upper-case MACs still receive commands.

Build:
- Apply a new mqtt-callback-guard.patch in the Docker build to patch upstream MQTT callback behavior.
- Pin the GitHub Actions Home Assistant builder workflow to version 2026.03.2 to match available builder images.

Documentation:
- Document the 0.6.10 release and its MQTT reliability fixes in the changelog.