### PR TITLE
ci: migrate off the deprecated home-assistant/builder action

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -85,6 +85,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # Cosign signs keylessly against an OIDC token
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.init.outputs.matrix) }}
@@ -104,6 +105,6 @@ jobs:
           image-tags: |
             ${{ needs.init.outputs.version }}
             latest
-          cosign: "false"
+          cosign: "true"
           push: ${{ github.event_name == 'push' }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,110 +1,102 @@
 name: Builder
 
-env:
-  BUILD_ARGS: "--test"
-  MONITORED_FILES: "build.yaml config.yaml Dockerfile apparmor.txt"
-
 on:
   push:
     branches:
       - master
+    paths:
+      - "broadlink-ac-mqtt/**"
+      - ".github/workflows/builder.yaml"
   pull_request:
     branches:
       - master
+    paths:
+      - "broadlink-ac-mqtt/**"
+      - ".github/workflows/builder.yaml"
+
+env:
+  ADDON_PATH: broadlink-ac-mqtt
+
+permissions:
+  contents: read
 
 jobs:
   init:
     runs-on: ubuntu-latest
-    name: Initialize builds
+    name: Read add-on metadata
     outputs:
-      changed_addons: ${{ steps.changed_addons.outputs.addons }}
-      changed: ${{ steps.changed_addons.outputs.changed }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      version: ${{ steps.addon.outputs.version }}
+      build_from: ${{ steps.addon.outputs.build_from }}
+      labels: ${{ steps.addon.outputs.labels }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v7.0.1
 
-      - name: Get changed files
-        id: changed_files
-        uses: jitterbit/get-changed-files@v1
-
-      - name: Find add-on directories
-        id: addons
-        uses: home-assistant/actions/helpers/find-addons@master
-
-      - name: Get changed add-ons
-        id: changed_addons
+      - name: Read config.yaml and build.yaml
+        id: addon
         run: |
-          declare -a changed_addons
-          for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
-              for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
-                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
-                      changed_addons+=("\"${addon}\",");
-                    fi
-                  fi
-              done
-            fi
-          done
-          changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
-          if [[ -n ${changed} ]]; then
-            echo "Changed add-ons: $changed";
-            echo "changed=true" >> "$GITHUB_OUTPUT";
-            echo "addons=[$changed]" >> "$GITHUB_OUTPUT";
-          else
-            echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
-          fi
+          config="${ADDON_PATH}/config.yaml"
+          build="${ADDON_PATH}/build.yaml"
+
+          # config.yaml is the source of truth the Supervisor pulls from, so the
+          # registry prefix and image name come from it rather than from the repo
+          # owner. prepare-multi-arch-matrix re-adds the "<arch>-" prefix.
+          raw_image=$(yq '.image' "${config}")
+          image_name=${raw_image##*/}
+          {
+            echo "registry_prefix=${raw_image%/*}"
+            echo "image_name=${image_name#\{arch\}-}"
+            echo "version=$(yq '.version' "${config}")"
+            echo "architectures=$(yq -o=json -I=0 '.arch' "${config}")"
+            echo "build_from=$(yq -o=json -I=0 '.build_from' "${build}")"
+          } >> "$GITHUB_OUTPUT"
+
+          # Labels the retired builder derived from config.yaml, plus whatever
+          # build.yaml declares. io.hass.arch/version and org.opencontainers.image
+          # created/source/version are added by build-image itself.
+          {
+            echo "labels<<EOF"
+            yq '"io.hass.name=" + .name, "io.hass.description=" + .description, "io.hass.url=" + .url' "${config}"
+            echo "io.hass.type=addon"
+            yq '.labels | to_entries[] | .key + "=" + .value' "${build}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare build matrix
+        id: matrix
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
+        with:
+          architectures: ${{ steps.addon.outputs.architectures }}
+          image-name: ${{ steps.addon.outputs.image_name }}
+          registry-prefix: ${{ steps.addon.outputs.registry_prefix }}
+
   build:
     needs: init
-    runs-on: ubuntu-latest
-    if: needs.init.outputs.changed == 'true'
-    name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
+    name: Build ${{ matrix.arch }} add-on
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
-      matrix:
-        addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64"]
-
+      fail-fast: false
+      matrix: ${{ fromJson(needs.init.outputs.matrix) }}
     steps:
-      - name: Check out repository
+      - name: Check out the repository
         uses: actions/checkout@v7.0.1
 
-      - name: Get information
-        id: info
-        uses: home-assistant/actions/helpers/info@master
+      - name: Build ${{ matrix.arch }} add-on
+        uses: home-assistant/builder/actions/build-image@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
-          path: "./${{ matrix.addon }}"
-
-      - name: Check if add-on should be built
-        id: check
-        run: |
-          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-             echo "build_arch=true" >> "$GITHUB_OUTPUT";
-             echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> "$GITHUB_OUTPUT";
-             if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-                 echo "BUILD_ARGS=" >> $GITHUB_ENV;
-             fi
-           else
-             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-             echo "build_arch=false" >> "$GITHUB_OUTPUT";
-          fi
-      - name: Login to GitHub Container Registry
-        if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v4.5.1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build ${{ matrix.addon }} add-on
-        if: steps.check.outputs.build_arch == 'true'
-        # Pinned to the newest release that has a matching ghcr.io/home-assistant/{arch}-builder
-        # image. 2026.06.0 has no published image, so pulling it fails with "manifest unknown".
-        uses: home-assistant/builder@2026.03.2
-        with:
-          args: |
-            ${{ env.BUILD_ARGS }} \
-            --${{ matrix.arch }} \
-            --target /data/${{ matrix.addon }} \
-            --image "${{ steps.check.outputs.image }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
-            --addon
+          arch: ${{ matrix.arch }}
+          image: ${{ matrix.image }}
+          version: ${{ needs.init.outputs.version }}
+          context: ${{ env.ADDON_PATH }}
+          build-args: BUILD_FROM=${{ fromJson(needs.init.outputs.build_from)[matrix.arch] }}
+          labels: ${{ needs.init.outputs.labels }}
+          image-tags: |
+            ${{ needs.init.outputs.version }}
+            latest
+          cosign: "false"
+          push: ${{ github.event_name == 'push' }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -27,7 +27,6 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       version: ${{ steps.addon.outputs.version }}
-      build_from: ${{ steps.addon.outputs.build_from }}
       labels: ${{ steps.addon.outputs.labels }}
     steps:
       - name: Check out the repository
@@ -49,7 +48,6 @@ jobs:
             echo "image_name=${image_name#\{arch\}-}"
             echo "version=$(yq '.version' "${config}")"
             echo "architectures=$(yq -o=json -I=0 '.arch' "${config}")"
-            echo "build_from=$(yq -o=json -I=0 '.build_from' "${build}")"
           } >> "$GITHUB_OUTPUT"
 
           # Labels the retired builder derived from config.yaml, plus whatever
@@ -64,12 +62,21 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Prepare build matrix
-        id: matrix
+        id: base
         uses: home-assistant/builder/actions/prepare-multi-arch-matrix@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
           architectures: ${{ steps.addon.outputs.architectures }}
           image-name: ${{ steps.addon.outputs.image_name }}
           registry-prefix: ${{ steps.addon.outputs.registry_prefix }}
+
+      - name: Carry each architecture's build_from in the matrix
+        id: matrix
+        env:
+          BASE_MATRIX: ${{ steps.base.outputs.matrix }}
+        run: |
+          build_from=$(yq -o=json -I=0 '.build_from' "${ADDON_PATH}/build.yaml")
+          matrix=$(jq -c --argjson from "${build_from}" '.include |= map(. + {build_from: $from[.arch]})' <<< "${BASE_MATRIX}")
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   build:
     needs: init
@@ -92,7 +99,7 @@ jobs:
           image: ${{ matrix.image }}
           version: ${{ needs.init.outputs.version }}
           context: ${{ env.ADDON_PATH }}
-          build-args: BUILD_FROM=${{ fromJson(needs.init.outputs.build_from)[matrix.arch] }}
+          build-args: BUILD_FROM=${{ matrix.build_from }}
           labels: ${{ needs.init.outputs.labels }}
           image-tags: |
             ${{ needs.init.outputs.version }}


### PR DESCRIPTION
Follow-up to #70, where the deprecation surfaced.

## Why

`home-assistant/builder` prints on every run:

> The home-assistant/builder action is deprecated and no longer maintained. Please check https://github.com/home-assistant/builder and migrate the workflow to the new reusable actions.

Its builder images stopped being published, which is what broke the `2026.06.0` pin and silently kept 0.6.9 from ever shipping. `2026.03.2` works today but is the last release with an image, so the pin is a dead end.

## What changed

`home-assistant/builder` → the reusable actions from the same repo:

- `prepare-multi-arch-matrix` builds the arch / runner-OS / image-name matrix
- `build-image` does buildx, labels, cache and push

Neither knows anything about add-on metadata, so a new `init` job reads it. Version, image name, registry prefix, supported architectures and per-arch `build_from` all come from `config.yaml` and `build.yaml`, so those stay the single source of truth the Supervisor reads too. The registry prefix is taken from `config.yaml`'s `image:` rather than from `github.repository_owner`, because that is the string the Supervisor actually pulls.

The labels the retired builder derived from `config.yaml` are reproduced explicitly (`io.hass.name`, `io.hass.description`, `io.hass.url`, `io.hass.type=addon`); `io.hass.arch`, `io.hass.version` and `org.opencontainers.image.created/source/version` come from `build-image`; the rest come from `build.yaml` as before.

Verified against the **published** `amd64-addon-broadlink-ac-mqtt:0.6.10` image — the resulting label set matches it exactly, and the yq extractions were run against the real `config.yaml`/`build.yaml`:

```
registry_prefix=ghcr.io/arbuzov
image_name=addon-broadlink-ac-mqtt
version=0.6.10
architectures=["aarch64","amd64"]
build_from={"aarch64":"...aarch64-base-python:3.13-alpine3.22","amd64":"...amd64-base-python:3.13-alpine3.22"}
```

## Change detection removed

`jitterbit/get-changed-files@v1` and `home-assistant/actions/helpers/find-addons@master` were two unpinned third-party actions doing work that native `paths:` filters do for a repo with one add-on. The old `MONITORED_FILES` set (`build.yaml config.yaml Dockerfile apparmor.txt`) also covered neither `rootfs/` nor `patches/`, so an s6 script or patch change would not have triggered a rebuild — `broadlink-ac-mqtt/**` fixes that. Adding the workflow itself to `paths:` closes the hole that let a broken builder pin sit green for a month: this PR builds itself.

## Notes

- Both reusable actions are **pinned by commit SHA** (`4de3518` = 2026.06.0). The old builder could not be SHA-pinned — it derived the builder image tag from the ref you pinned, so a SHA became an image tag that was never published. That was the Sourcery suggestion on #70 that had to be rejected; it applies cleanly here.
- `aarch64` now builds natively on `ubuntu-24.04-arm` instead of under QEMU.
- **Images are now signed.** The retired builder defaulted `COSIGN=false` and the workflow never passed `--cosign`, so add-on images were never signed; `cosign: "true"` plus `id-token: write` turns on keyless signing of the manifest digest, which covers both the version and `latest` tags.
  With cosign on, `build-image` also cosign-verifies the registry cache image before reusing it. `<arch>-addon-broadlink-ac-mqtt:latest` is currently unsigned, so that check retries five times, warns (`allow-failure: true`) and the build falls back to `--cache-from type=gha` alone — visible as amd64 going 37s → 2m9s on this run. It self-heals once the first signed `latest` is pushed on merge.
  The signing step itself is `if: push == true`, so it cannot execute on a pull request; the first real signature happens on merge to master.
- `build-image` pushes zstd/OCI layers where the old builder pushed gzip/Docker v2. Not a new requirement: `ghcr.io/home-assistant/{arch}-base-python`, the base this add-on builds FROM, is already `application/vnd.oci.image.layer.v1.tar+zstd`.
- Merging rebuilds and re-pushes `0.6.10` and `latest` through the new pipeline, which is the real end-to-end check. The add-on version is deliberately not bumped — nothing in the image content changed.
- `lint.yaml` still uses `home-assistant/actions/helpers/find-addons@master`; left alone, out of scope here.

`actionlint` is clean on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate the builder GitHub Actions workflow to Home Assistant’s reusable multi-arch builder actions and simplify triggering to build the single add-on in this repository.

CI:
- Replace the deprecated home-assistant/builder action with the prepare-multi-arch-matrix and build-image reusable actions pinned by commit SHA.
- Introduce an init job that reads add-on metadata from config.yaml and build.yaml to define the build matrix, image name, version, architectures, build-from mapping, and labels.
- Switch workflow triggers to path-based filters for the add-on directory and the builder workflow file, removing third-party change-detection actions and monitored file logic.
- Adjust the build job to run on per-arch runners, push images only on push events, and emit version and latest tags with explicit Hass/OCI labels derived from repo config.
