### PR TITLE
0.7.1: an unnamed fan speed no longer ends the poll

### DIFF
--- a/broadlink-ac-mqtt/CHANGELOG.md
+++ b/broadlink-ac-mqtt/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.7.1
+
+- Fix a crash on the first status read for any AC reporting a fan speed the driver does not name: `get_key()` hands back the raw integer, and `.title()` on an integer ended the poll with `AttributeError: 'int' object has no attribute 'title'` ([#67](https://github.com/Arbuzov/hass-broadlink-ac-mqtt/issues/67)). An unnamed speed now reports as `Auto`, the way an unnamed swing position already did
+- `NONE` reports as `Auto` too: it is a speed the driver names but never one of the `fan_modes` announced to Home Assistant, so it would have been rejected on arrival. Mute and Turbo still label themselves
+
 ## 0.7.0
 
 - Consume `Arbuzov/broadlink_ac_mqtt@1.2.4` directly instead of patching 1.2.3 at build time: both downstream patches (`skip-unreachable-devices`, `mqtt-callback-guard`) are now upstream, so `patches/` and the `patch -p1` chain are gone

--- a/broadlink-ac-mqtt/Dockerfile
+++ b/broadlink-ac-mqtt/Dockerfile
@@ -1,12 +1,12 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-## Upstream release 1.2.4, pinned by commit rather than by tag: a tag can be
-## moved, and then the same add-on version would build different code with
-## nothing in this repository to show for it. Applying the patches used to catch
-## that by accident, because their context stopped matching. Bump together with
-## config.yaml's version.
-ARG UPSTREAM_COMMIT=8a47929690d9426f8fbe355f97ef3ba6c6a64dae
+## Upstream 1.2.4 plus the unmapped-fan-speed fix, pinned by commit rather than
+## by tag: a tag can be moved, and then the same add-on version would build
+## different code with nothing in this repository to show for it. Applying the
+## patches used to catch that by accident, because their context stopped
+## matching. Bump together with config.yaml's version.
+ARG UPSTREAM_COMMIT=b86c16b5c17b5a8a3350684e9f1efeec892ef3f8
 
 COPY rootfs /
 

--- a/broadlink-ac-mqtt/config.yaml
+++ b/broadlink-ac-mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: AC MQTT proxy for home assistant
-version: 0.7.0
+version: 0.7.1
 slug: broadlink-ac-mqtt
 description: Provides AC MQTT proxy for home assistant
 url: "https://github.com/Arbuzov/hass-broadlink-ac-mqtt"


### PR DESCRIPTION
Picks up [Arbuzov/broadlink_ac_mqtt#5](https://github.com/Arbuzov/broadlink_ac_mqtt/pull/5), which fixes #67.

`get_key()` returns the raw integer when a value is not in the table, and `make_nice_status` called `.title()` on it. `STATIC.FAN` names 0, 1, 2, 3 and 5, so an AC reporting anything else raised `AttributeError: 'int' object has no attribute 'title'` out of `get_ac_states` — on the first status read, before the add-on had published anything. The reporter's add-on never got past startup.

An unnamed speed now reports as `Auto`, the fallback the unmapped swing position already had. `NONE` joins it: the driver names it, but `"None"` was never one of the `fan_modes` in the discovery payload, so Home Assistant would have rejected it on arrival exactly as it rejected a bare integer. Mute and Turbo still overwrite the label, so a muted unit is unaffected.

Upstream carries tests for all four cases; the two describing the bug fail without the change. `UPSTREAM_COMMIT` moves to `b86c16b`, the merge of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the add-on to consume an upstream commit that fixes handling of unmapped fan speeds and release it as version 0.7.1.

Bug Fixes:
- Prevent a startup crash when an AC reports a fan speed or NONE value that is not named by the driver by mapping these cases to Auto.

Build:
- Bump the pinned upstream broadlink_ac_mqtt commit to include the unmapped-fan-speed fix.

Documentation:
- Add a 0.7.1 changelog entry describing the fix for crashes caused by unmapped fan speeds.

Chores:
- Increment the add-on version from 0.7.0 to 0.7.1 in config.yaml.